### PR TITLE
fix: add 404.html fallback for GitHub Pages SPA routing

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "tsc -b && vite build",
+    "build": "tsc -b && vite build && cp dist/index.html dist/404.html",
     "lint": "eslint .",
     "preview": "vite preview"
   },


### PR DESCRIPTION
#### Summary

* Added fallback handling for SPA routing by copying `index.html` to `404.html` after build.
* This ensures sub-routes like `/web/bulletin` correctly render on GitHub Pages without triggering a 404 error.
* The base path setting in `vite.config.ts` was **not changed**, as it was already correctly set to `'/web/'`.

#### Testing

* Deployment successfully verified at: [https://cjzrv.github.io/web/bulletin](https://cjzrv.github.io/web/bulletin)
* All sub-routes now load properly without 404 errors.

#### Notes

* After this PR is merged, I will delete my forked repository (`cjzrv/web`) as it is no longer needed.